### PR TITLE
Use a hard-coded UUID for the failing example to get it to work

### DIFF
--- a/example/bcachefs.nix
+++ b/example/bcachefs.nix
@@ -129,8 +129,9 @@
         };
       };
 
-      # Example showing a bcachefs filesystem without subvolumes
-      # and which relies on a subvolume in another filesystem being mounted.
+      # Example showing a bcachefs filesystem without subvolumes,
+      # which relies on a subvolume in another filesystem being mounted
+      # and uses a hard-coded UUID.
       relies_on_external_subvolume = {
         type = "bcachefs_filesystem";
         mountpoint = "/home/Documents";
@@ -141,6 +142,7 @@
         mountOptions = [
           "verbose"
         ];
+        uuid = "64e50034-ebe2-eaf8-1f93-cf56266a8d86";
       };
     };
   };

--- a/tests/bcachefs.nix
+++ b/tests/bcachefs.nix
@@ -109,7 +109,7 @@ diskoLib.testLib.makeDiskoTest {
             | .. \
             | select(.target? == "/home/Documents") \
             | .source \
-            | contains("/dev/vdd1") \
+            | contains("/dev/disk/by-uuid/64e50034-ebe2-eaf8-1f93-cf56266a8d86") \
         '
     """);
 


### PR DESCRIPTION
@ProjectInitiative Your changes requires one of the filesystems to use a hardcoded UUID to allow the test to succeed, which this PR addresses.

To be frank, I think some of my tests are a bit flakey, so if you have some ideas on how to improve them, please feel free to do so.